### PR TITLE
65 employee httprequestmethodnotsupportedexception handler

### DIFF
--- a/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/dto/ApiError.java
+++ b/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/dto/ApiError.java
@@ -45,6 +45,10 @@ public class ApiError {
         return new ApiError(message, NOT_FOUND.value(), subErrors);
     }
 
+    public static ApiError methodNotAllowed(String message) {
+        return new ApiError(message, METHOD_NOT_ALLOWED.value());
+    }
+
     @Override
     public String toString() {
         return "ApiError{" +

--- a/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandler.java
+++ b/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandler.java
@@ -9,9 +9,26 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import static com.senla.worklog.reminder.employee.adapter.in.rest.dto.ApiError.methodNotAllowed;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 
+/**
+ * An exception handler for handling {@link HttpRequestMethodNotSupportedException}, which is thrown when a
+ * request handler does not support a specific request method. This handler returns a HTTP 405 Method Not Allowed
+ * response with a user-friendly error message.
+ */
 @Slf4j
 @Component
 public class HttpRequestMethodNotSupportedExceptionHandler extends AbstractRestAdapterExceptionHandler {
+
+    /**
+     * Handles the {@link HttpRequestMethodNotSupportedException} and returns a HTTP 405 Method Not Allowed response
+     * with a user-friendly error message
+     * <p>
+     * If the passed exception is not an instance of HttpMessageNotReadableException, it delegates
+     * the handling to the parent class method {@link #handleUnsupportedExceptionType(Exception)} handleUnsupportedExceptionType()}
+     *
+     * @param e the {@link HttpRequestMethodNotSupportedException} to handle
+     * @return a {@link ResponseEntity} containing an {@link ApiError} with a HTTP 405 status code and
+     * a user-friendly error message
+     */
     @Override
     public ResponseEntity<ApiError> handleException(Exception e) {
         if (e instanceof HttpRequestMethodNotSupportedException) {
@@ -23,6 +40,11 @@ public class HttpRequestMethodNotSupportedExceptionHandler extends AbstractRestA
         return handleUnsupportedExceptionType(e);
     }
 
+    /**
+     * Returns the type of exception that this handler can handle, which is {@link HttpRequestMethodNotSupportedException}.
+     *
+     * @return the {@link HttpRequestMethodNotSupportedException} class
+     */
     @Override
     public Class<? extends Throwable> getExceptionType() {
         return HttpRequestMethodNotSupportedException.class;

--- a/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandler.java
+++ b/services/employee/src/main/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.senla.worklog.reminder.employee.adapter.in.rest.exception.handler;
+
+import com.senla.worklog.reminder.employee.adapter.in.rest.dto.ApiError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+
+import static com.senla.worklog.reminder.employee.adapter.in.rest.dto.ApiError.methodNotAllowed;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+
+@Slf4j
+@Component
+public class HttpRequestMethodNotSupportedExceptionHandler extends AbstractRestAdapterExceptionHandler {
+    @Override
+    public ResponseEntity<ApiError> handleException(Exception e) {
+        if (e instanceof HttpRequestMethodNotSupportedException) {
+            log.debug("Resolved HttpRequestMethodNotSupportedException: {}", e.getMessage());
+            var message = e.getMessage();
+            var apiError = methodNotAllowed(message);
+            return new ResponseEntity<>(apiError, METHOD_NOT_ALLOWED);
+        }
+        return handleUnsupportedExceptionType(e);
+    }
+
+    @Override
+    public Class<? extends Throwable> getExceptionType() {
+        return HttpRequestMethodNotSupportedException.class;
+    }
+}

--- a/services/employee/src/test/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandlerTest.java
+++ b/services/employee/src/test/java/com/senla/worklog/reminder/employee/adapter/in/rest/exception/handler/HttpRequestMethodNotSupportedExceptionHandlerTest.java
@@ -1,0 +1,39 @@
+package com.senla.worklog.reminder.employee.adapter.in.rest.exception.handler;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+
+class HttpRequestMethodNotSupportedExceptionHandlerTest {
+    private final HttpRequestMethodNotSupportedExceptionHandler exceptionHandler = new HttpRequestMethodNotSupportedExceptionHandler();
+
+    @Test
+    public void handleException_shouldReturn405_whenInputIsHttpRequestMethodNotSupportedException() {
+        var exception = new HttpRequestMethodNotSupportedException("method name");
+
+        var responseEntity = exceptionHandler.handleException(exception);
+
+        assertEquals(responseEntity.getStatusCode(), METHOD_NOT_ALLOWED);
+        assertNotNull(responseEntity.getBody());
+        assertEquals(responseEntity.getBody().getMessage(), "Request method 'method name' not supported");
+        assertEquals(responseEntity.getBody().getStatus(), 405);
+    }
+
+    @Test
+    public void handleException_shouldReturn500_whenInputIsUnsupportedExceptionType() {
+        var responseEntity = exceptionHandler.handleException(new IllegalCallerException());
+
+        assertEquals(responseEntity.getStatusCode(), INTERNAL_SERVER_ERROR);
+        assertNotNull(responseEntity.getBody());
+        assertEquals(responseEntity.getBody().getStatus(), 500);
+    }
+
+    @Test
+    public void getExceptionType_shouldReturnHttpRequestMethodNotSupportedException() {
+        assertEquals(HttpRequestMethodNotSupportedException.class, exceptionHandler.getExceptionType());
+    }
+}


### PR DESCRIPTION
1. Added HttpRequestMethodNotSupportedExceptionHandler class in adapter.exception.handler package to handle HttpRequestMethodNotSupportedException exceptions and return a ApiError with meaningful error message to the client
2. Added unit tests to verify that the new handler is working correctly
3. Added javadocs